### PR TITLE
Fix typo in podspec of project homepage

### DIFF
--- a/JVFloatLabeledTextField.podspec
+++ b/JVFloatLabeledTextField.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "JVFloatLabeledTextField"
   s.version      = "0.0.1"
   s.summary      = "UITextField subclass that turns placeholders into floating labels once filled in."
-  s.homepage     = "http://github.com/jverdi/JVFloatLabeledField"
+  s.homepage     = "http://github.com/jverdi/JVFloatLabeledTextField"
   s.screenshot   = "https://github-camo.global.ssl.fastly.net/be57d040ec0ce5d6467fb73564c6bcb6c76d5a7b/687474703a2f2f6472696262626c652e73332e616d617a6f6e6177732e636f6d2f75736572732f363431302f73637265656e73686f74732f313235343433392f666f726d2d616e696d6174696f6e2d5f6769665f2e676966"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Jared Verdi" => "jared@jaredverdi.com" }


### PR DESCRIPTION
Was missing 'Text' in 'TextField', causing link to 404. Discovered this when Cocoapods tweeted out the link to your project on Twitter.
