### PR TITLE
Add UIAppearance properties

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -31,6 +31,7 @@
 @interface JVFloatLabeledTextField : UITextField
 
 @property (nonatomic, strong, readonly) UILabel * floatingLabel;
+@property (nonatomic, strong) UIFont * floatingLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor * floatingLabelTextColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor * floatingLabelActiveTextColor UI_APPEARANCE_SELECTOR; // tint color is used by default if not provided
 

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -106,12 +106,10 @@
             [self hideFloatingLabel];
         }
         else {
-            if (self.floatingLabelActiveTextColor) {
-                _floatingLabel.textColor = self.floatingLabelActiveTextColor;
+            if (self.floatingLabelFont) {
+                _floatingLabel.font = self.floatingLabelFont;
             }
-            else {
-                _floatingLabel.textColor = self.tintColor;
-            }
+            [self setLabelActiveColor];
             [self showFloatingLabel];
         }
     }
@@ -120,6 +118,15 @@
         if (!self.text || 0 == [self.text length]) {
             [self hideFloatingLabel];
         }
+    }
+}
+
+- (void)setLabelActiveColor {
+    if (self.floatingLabelActiveTextColor) {
+        _floatingLabel.textColor = self.floatingLabelActiveTextColor;
+    }
+    else {
+        _floatingLabel.textColor = self.tintColor;
     }
 }
 


### PR DESCRIPTION
## Reasoning

If you add several of the floating label properties as UIAppearance selectors, it makes it so that you don't have to configure every single instance. I've been considering using this in an app that has tons of text fields in it, which makes UIAppearance nearly a requirement for single setup. However, this doesn't prohibit setting the properties exactly as they are on each instance. Also, you will override the UIAppearance property if you that property specifically on an instance.
## UIAppearance Properties
- [Added] `floatingLabelFont`
- [Updated] `floatingLabelTextColor`
- [Updated] `floatingLabelActiveTextColor`
## Example Usage

Here's a simple example of how to use these UIAppearance properties if anyone is unfamiliar. This code must be executed before the 1st initialization of a `JVFloatLabeledTextField`:

``` objc
[[JVFloatLabeledTextField appearance] setFloatingLabelActiveTextColor:[UIColor redColor]];
[[JVFloatLabeledTextField appearance] setFloatingLabelFont:[UIFont fontWithName:@"HelveticaNeue-UltraLight" size:kJVFieldFloatingLabelFontSize]];
```
