### PR TITLE
Show floatingLabel for case that field's value that has alreay been set

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -119,6 +119,8 @@
         _floatingLabel.textColor = self.floatingLabelTextColor;
         if (!self.text || 0 == [self.text length]) {
             [self hideFloatingLabel];
+        } else {
+            [self showFloatingLabel];
         }
     }
 }


### PR DESCRIPTION
Sometimes field has alreay binded a value, in this case, we should allow it to show the `floatingLabel` by sending

```
[self setNeedsLayout];
```
