### PR TITLE
Fix the location of the clear button.

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -99,7 +99,7 @@
 - (CGRect)clearButtonRectForBounds:(CGRect)bounds
 {
 	CGRect rect = [super clearButtonRectForBounds:bounds];
-	rect = CGRectMake(rect.origin.x, rect.origin.y + _floatingLabel.font.lineHeight+_floatingLabelYPadding.floatValue / 2.0f, rect.size.width, rect.size.height);
+	rect = CGRectMake(rect.origin.x, rect.origin.y + (_floatingLabel.font.lineHeight / 2.0) + (_floatingLabelYPadding.floatValue / 2.0f), rect.size.width, rect.size.height);
 	return rect;
 }
 


### PR DESCRIPTION
The clearButtonRectForBounds method was returning a rect that made the
clear button appear too low in the UITextField.  Instead of adding the
entire line height to the y coordinate, it should only be adding half
of the line height so that the clear button is vertically centered with
the text.
