### PR TITLE
Added ability to disable pasting to JVFloatLabeledTextField

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -36,5 +36,6 @@
 @property (nonatomic, strong) UIColor * floatingLabelTextColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor * floatingLabelActiveTextColor UI_APPEARANCE_SELECTOR; // tint color is used by default if not provided
 @property (nonatomic, assign) NSInteger animateEvenIfNotFirstResponder UI_APPEARANCE_SELECTOR; // Can't use BOOL for UI_APPEARANCE. Non-zero == YES
+@property (nonatomic, assign) BOOL disablePasting; // Default is NO
 
 @end

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -200,6 +200,15 @@
     }
 }
 
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+    if (action == @selector(paste:)) {
+        return (_disablePasting) ? NO : YES;
+    }
+    
+    return [super canPerformAction:action withSender:sender];
+}
+
 #pragma mark - Accessibility
 
 - (NSString *)accessibilityLabel


### PR DESCRIPTION
There exist certain situations where I, and others, may want to disallow pasting in a textfield. For instance, if I want the last 4 digits of someone's SSN, or their phone number, I only want to allow numbers in the text field. There are three ways of enforcing this condition:
- Using `UIKeyboardTypeNumberPad`.
- Another way, is by monitoring every character that gets entered Using `- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string`.
  - This second option an ugly way of doing it.
- Logic, coupled with passive or active alerts

However, the first two options can be circumvented by allowing data from a different field to be pasted into this field. The third option is just annoying. A cleaner, more elegant manner of implementing this feature is to disallow pasting into the textfield. This can be achieved using the `canPerformAction:withSender` UIResponder method. However, this method must be implemented inside a subclassed UITextField. I have done just that within JVFloatLabeledTextField .h/.m.

As I use CocoaPods to manage your repo, and I'm not wanting to subclass JVFloatLabeledTextField directly within my project (e.g., lazy), I decided to create this change and submit it to you for your evaluation.

Hopefully, I've presented my case, and that you'll consider adding this change.

Thanks for your consideration!
