### PR TITLE
Set the floating title independently from the placeholder.

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -37,4 +37,12 @@
 @property (nonatomic, strong) UIColor * floatingLabelActiveTextColor UI_APPEARANCE_SELECTOR; // tint color is used by default if not provided
 @property (nonatomic, assign) NSInteger animateEvenIfNotFirstResponder UI_APPEARANCE_SELECTOR; // Can't use BOOL for UI_APPEARANCE. Non-zero == YES
 
+/**
+ *  Sets the placeholder and the floating title
+ *
+ *  @param placeholder   The string that is displayed when there is no other text in the text field.
+ *  @param floatingTitle The string that is displayed above the text field when it's not empty.
+ */
+- (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle;
+
 @end

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -80,7 +80,7 @@
     return [UIColor blueColor];
 }
 
-- (void) setFloatingLabelFont:(UIFont *)floatingLabelFont
+- (void)setFloatingLabelFont:(UIFont *)floatingLabelFont
 {
     _floatingLabelFont = floatingLabelFont;
     _floatingLabel.font = (_floatingLabelFont ? _floatingLabelFont : [UIFont boldSystemFontOfSize:12.0f]);
@@ -156,6 +156,14 @@
     [super setPlaceholder:placeholder];
     
     _floatingLabel.text = placeholder;
+    [_floatingLabel sizeToFit];
+}
+
+- (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle
+{
+    [super setPlaceholder:placeholder];
+
+    _floatingLabel.text = floatingTitle;
     [_floatingLabel sizeToFit];
 }
 

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.h
@@ -19,4 +19,12 @@
 @property (nonatomic, strong) UIColor * floatingLabelActiveTextColor UI_APPEARANCE_SELECTOR; // tint color is used by default if not provided
 @property (nonatomic, assign) NSInteger animateEvenIfNotFirstResponder UI_APPEARANCE_SELECTOR; // Can't use BOOL for UI_APPEARANCE. Non-zero == YES
 
+/**
+ *  Sets the placeholder and the floating title
+ *
+ *  @param placeholder   The string that is displayed when there is no other text in the text view.
+ *  @param floatingTitle The string that is displayed above the text view when it's not empty.
+ */
+- (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle;
+
 @end

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -101,6 +101,16 @@
     [_floatingLabel sizeToFit];
 }
 
+- (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle
+{
+    _placeholder = placeholder;
+    _placeholderLabel.text = placeholder;
+    [_placeholderLabel sizeToFit];
+
+    _floatingLabel.text = floatingTitle;
+    [_floatingLabel sizeToFit];
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];
@@ -221,7 +231,7 @@
     return rect;
 }
 
-- (void) setFloatingLabelFont:(UIFont *)floatingLabelFont
+- (void)setFloatingLabelFont:(UIFont *)floatingLabelFont
 {
     _floatingLabelFont = floatingLabelFont;
     _floatingLabel.font = (_floatingLabelFont ? _floatingLabelFont : [UIFont boldSystemFontOfSize:12.0f]);


### PR DESCRIPTION
Adding the ability to set the floating title independently from the placeholder.
Can be useful if the placeholder is not exactly what you would use as a title, e.g.:
Placeholder: "Specific Location (optional)"
Floating title: "Specific Location" 
In this case, once the user starts entering a value, then the value is -by definition- not optional anymore.

Also: Code formatting.
