### PR TITLE
Fix attributedPlaceholder

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -161,6 +161,14 @@
     [_floatingLabel sizeToFit];
 }
 
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder
+{
+    [super setAttributedPlaceholder:attributedPlaceholder];
+	
+    _floatingLabel.text = attributedPlaceholder.string;
+    [_floatingLabel sizeToFit];
+}
+
 - (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle
 {
     [super setPlaceholder:placeholder];


### PR DESCRIPTION
When using an attributed placeholder the string of the floating label wasn't set. This resulted in the floating label no having any content, and therefore not visible.

Current work-around:

```
_textField.placeholder = @"Title";
_textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:@"Title" attributes:@{}];
```
