### PR TITLE
Update placeholder color for iOS 7

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -255,7 +255,7 @@
 
 + (UIColor *)defaultiOSPlaceholderColor
 {
-    return [UIColor colorWithWhite:0.702f alpha:1.0f];
+    return [[UIColor lightGrayColor] colorWithAlphaComponent:0.65f];
 }
 
 #pragma mark - UITextView


### PR DESCRIPTION
I think current placeholder color does not match default iOS 7 color. This one is much closer.
