### PR TITLE
Added support for underline of the TextField.

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -59,14 +59,14 @@
 @property (nonatomic) CGFloat placeholderYPadding UI_APPEARANCE_SELECTOR;
 
 /**
- * Font to be applied to the floating label. 
+ * Font to be applied to the floating label.
  * Defaults to `[UIFont boldSystemFontOfSize:12.0f]`.
  * Provided for the convenience of using as an appearance proxy.
  */
 @property (nonatomic, strong) UIFont * floatingLabelFont UI_APPEARANCE_SELECTOR;
 
 /**
- * Text color to be applied to the floating label. 
+ * Text color to be applied to the floating label.
  * Defaults to `[UIColor grayColor]`.
  * Provided for the convenience of using as an appearance proxy.
  */
@@ -86,16 +86,32 @@
 @property (nonatomic, assign) NSInteger animateEvenIfNotFirstResponder UI_APPEARANCE_SELECTOR;
 
 /**
- * Duration of the animation when showing the floating label. 
+ * Duration of the animation when showing the floating label.
  * Defaults to 0.3 seconds.
  */
 @property (nonatomic, assign) NSTimeInterval floatingLabelShowAnimationDuration UI_APPEARANCE_SELECTOR;
 
 /**
- * Duration of the animation when hiding the floating label. 
+ * Duration of the animation when hiding the floating label.
  * Defaults to 0.3 seconds.
  */
 @property (nonatomic, assign) NSTimeInterval floatingLabelHideAnimationDuration UI_APPEARANCE_SELECTOR;
+
+/**
+ * Determines if Textfield has an underline. Defaults to NO.
+ */
+@property (nonatomic) BOOL hasUnderline UI_APPEARANCE_SELECTOR;
+
+/**
+ * Hight to be applied to the underline. Defaults to 0.5f.
+ * 0.5f makes a perfect 1 pixel line on retina displays.
+ */
+@property (nonatomic) CGFloat underlineHight UI_APPEARANCE_SELECTOR;
+
+/**
+ * Color to be applied to the underline. Defaults to `[UIColor lightGrayColor]`.
+ */
+@property (nonatomic, strong) UIColor * underlineColor UI_APPEARANCE_SELECTOR;
 
 /**
  *  Sets the placeholder and the floating title

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -37,21 +37,21 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-	    [self commonInit];
+        [self commonInit];
     }
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder 
+- (id)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];
     if (self) {
         [self commonInit];
         
         // force setter to be called on a placeholder defined in a NIB/Storyboard
-    	if (self.placeholder) {
-        	self.placeholder = self.placeholder;
-    	}
+        if (self.placeholder) {
+            self.placeholder = self.placeholder;
+        }
     }
     return self;
 }
@@ -61,7 +61,7 @@
     _floatingLabel = [UILabel new];
     _floatingLabel.alpha = 0.0f;
     [self addSubview:_floatingLabel];
-	
+    
     // some basic default fonts/colors
     _floatingLabelFont = [UIFont boldSystemFontOfSize:12.0f];
     _floatingLabel.font = _floatingLabelFont;
@@ -71,6 +71,9 @@
     _animateEvenIfNotFirstResponder = NO;
     _floatingLabelShowAnimationDuration = kFloatingLabelShowAnimationDuration;
     _floatingLabelHideAnimationDuration = kFloatingLabelHideAnimationDuration;
+    _hasUnderline = NO;
+    _underlineHight = 0.5f;
+    _underlineColor = [UIColor lightGrayColor];
 }
 
 #pragma mark -
@@ -123,7 +126,7 @@
                                           _floatingLabel.font.lineHeight + _placeholderYPadding,
                                           _floatingLabel.frame.size.width,
                                           _floatingLabel.frame.size.height);
-
+        
     };
     
     if (animated || _animateEvenIfNotFirstResponder) {
@@ -165,7 +168,7 @@
 - (void)setPlaceholder:(NSString *)placeholder
 {
     [super setPlaceholder:placeholder];
-
+    
     _floatingLabel.text = placeholder;
     [_floatingLabel sizeToFit];
 }
@@ -173,7 +176,7 @@
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder
 {
     [super setAttributedPlaceholder:attributedPlaceholder];
-	
+    
     _floatingLabel.text = attributedPlaceholder.string;
     [_floatingLabel sizeToFit];
 }
@@ -181,7 +184,7 @@
 - (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle
 {
     [super setPlaceholder:placeholder];
-
+    
     _floatingLabel.text = floatingTitle;
     [_floatingLabel sizeToFit];
 }
@@ -191,8 +194,8 @@
     CGRect rect = [super textRectForBounds:bounds];
     if ([self.text length]) {
         CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
-	topInset = MIN(topInset, [self maxTopInset]);
-	rect = UIEdgeInsetsInsetRect(rect, UIEdgeInsetsMake(topInset, 0.0f, 0.0f, 0.0f));
+        topInset = MIN(topInset, [self maxTopInset]);
+        rect = UIEdgeInsetsInsetRect(rect, UIEdgeInsetsMake(topInset, 0.0f, 0.0f, 0.0f));
     }
     return CGRectIntegral(rect);
 }
@@ -202,8 +205,8 @@
     CGRect rect = [super editingRectForBounds:bounds];
     if ([self.text length]) {
         CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
-	topInset = MIN(topInset, [self maxTopInset]);
-	rect = UIEdgeInsetsInsetRect(rect, UIEdgeInsetsMake(topInset, 0.0f, 0.0f, 0.0f));
+        topInset = MIN(topInset, [self maxTopInset]);
+        rect = UIEdgeInsetsInsetRect(rect, UIEdgeInsetsMake(topInset, 0.0f, 0.0f, 0.0f));
     }
     return CGRectIntegral(rect);
 }
@@ -212,9 +215,9 @@
 {
     CGRect rect = [super clearButtonRectForBounds:bounds];
     if ([self.text length]) {
-	CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
-	topInset = MIN(topInset, [self maxTopInset]);
-	rect = CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
+        CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
+        topInset = MIN(topInset, [self maxTopInset]);
+        rect = CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
     }
     return CGRectIntegral(rect);
 }
@@ -249,6 +252,33 @@
     else {
         [self showFloatingLabel:firstResponder];
     }
+    
+    if (_hasUnderline) {
+        [self addUnderlineView];
+    }
+}
+
+- (void)setHasUnderline:(BOOL)hasUnderline {
+    _hasUnderline = hasUnderline;
+}
+
+- (void)addUnderlineView {
+    CAShapeLayer *shapeLayer = [CAShapeLayer layer];
+    [shapeLayer setFrame:self.bounds];
+    [shapeLayer setStrokeColor:self.underlineColor.CGColor];
+    [shapeLayer setLineWidth:self.underlineHight];
+    [shapeLayer setLineJoin:kCALineJoinRound];
+    
+    CGFloat yOrigin = CGRectGetHeight(self.bounds) - self.underlineHight;
+    
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathMoveToPoint(path, NULL, 0, yOrigin);
+    CGPathAddLineToPoint(path, NULL, CGRectGetWidth(self.bounds), yOrigin);
+    
+    [shapeLayer setPath:path];
+    CGPathRelease(path);
+    
+    [self.layer addSublayer:shapeLayer];
 }
 
 #pragma mark - Accessibility

--- a/JVFloatLabeledTextFieldTests/JVFloatLabeledTextFieldTests.m
+++ b/JVFloatLabeledTextFieldTests/JVFloatLabeledTextFieldTests.m
@@ -59,6 +59,9 @@
     XCTAssertEqual(self.testField.animateEvenIfNotFirstResponder, 0);
     XCTAssertEqual(self.testField.floatingLabelShowAnimationDuration, 0.3f);
     XCTAssertEqual(self.testField.floatingLabelHideAnimationDuration, 0.3f);
+    XCTAssertEqual(self.testField.hasUnderline, NO);
+    XCTAssertEqual(self.testField.underlineHight, 0.5f);
+    XCTAssert(CGColorEqualToColor(self.testField.underlineColor.CGColor, [UIColor lightGrayColor].CGColor));
 }
 
 @end


### PR DESCRIPTION
I've added support for underlining the textfield.

There is a new bool value `hasUnderline` which defaults to NO. If you turn it on the - a straight line at the bottom of the TextField will appear. 

You can customize the `underlineColor` and `underlineHight` of the line.
The default values are `underlineColor = 0.5f` and  `underlineHight = [UIColor lightGrayColor]` which draws a perfect 1px line on retina displays.

Also added the corresponding tests.

I've used your component in my project and just wanted to share the enhancement I had to make for the given design. Major thanks for building this - it really is a beauty!:)
