### PR TITLE
Added adjustsClearButtonRect setting to give the option not to move the ...

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -99,6 +99,12 @@
 @property (nonatomic, assign) NSTimeInterval floatingLabelHideAnimationDuration UI_APPEARANCE_SELECTOR;
 
 /**
+ * Indicates whether the clearButton position is adjusted to align with the text
+ * Defaults to YES
+ */
+@property (nonatomic, assign) BOOL adjustsClearButtonRect;
+
+/**
  *  Sets the placeholder and the floating title
  *
  *  @param placeholder The string that to be shown in the text field when no other text is present.

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -102,7 +102,7 @@
  * Indicates whether the clearButton position is adjusted to align with the text
  * Defaults to YES
  */
-@property (nonatomic, assign) BOOL adjustsClearButtonRect;
+@property (nonatomic, assign) BOOL adjustsClearButtonRect UI_APPEARANCE_SELECTOR;
 
 /**
  *  Sets the placeholder and the floating title

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -67,6 +67,8 @@
     _floatingLabelShowAnimationDuration = kFloatingLabelShowAnimationDuration;
     _floatingLabelHideAnimationDuration = kFloatingLabelHideAnimationDuration;
     [self setFloatingLabelText:self.placeholder];
+    
+    _adjustsClearButtonRect = YES;
 }
 
 #pragma mark -
@@ -216,10 +218,12 @@
 - (CGRect)clearButtonRectForBounds:(CGRect)bounds
 {
     CGRect rect = [super clearButtonRectForBounds:bounds];
-    if ([self.text length]) {
-        CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
-        topInset = MIN(topInset, [self maxTopInset]);
-        rect = CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
+    if(self.adjustsClearButtonRect) {
+        if ([self.text length]) {
+            CGFloat topInset = ceilf(_floatingLabel.font.lineHeight + _placeholderYPadding);
+            topInset = MIN(topInset, [self maxTopInset]);
+            rect = CGRectMake(rect.origin.x, rect.origin.y + topInset / 2.0f, rect.size.width, rect.size.height);
+        }
     }
     return CGRectIntegral(rect);
 }


### PR DESCRIPTION
...clearButton down when editing. Some might prefer it this way so for example the clear button stays centered within a tableViewCell.

Example: adjustsClearButtonRect = true (default and same behaviour as before)
![screen shot 2015-01-23 at 14 44 58](https://cloud.githubusercontent.com/assets/8781023/5876353/6ed588fa-a30e-11e4-8b3f-73daeb260ec1.png)


adjustsClearButtonRect = false
![screen shot 2015-01-23 at 14 41 38](https://cloud.githubusercontent.com/assets/8781023/5876324/3ebdbab6-a30e-11e4-9e0e-e8cffcc32fa2.png)
