### PR TITLE
Small fix remove the issue

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -151,7 +151,10 @@
     [super layoutSubviews];
     [self adjustTextContainerInsetTop];
     
+    _placeholderLabel.frame = CGRectZero;
     [_placeholderLabel sizeToFit];
+    
+    _floatingLabel.frame = CGRectZero;
     [_floatingLabel sizeToFit];
     
     _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,


### PR DESCRIPTION
If you first assign "Beschrijving" (description in dutch) as the placeholder and after that you assign "Description" (description in french) and the placeholder label is getting smaller.
This small MR will fix that issue.