### PR TITLE
Remove fallback static font.

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -71,7 +71,6 @@ IB_DESIGNABLE
  * Defaults to the first applicable of the following:
  * - the custom specified attributed placeholder font at 70% of its size
  * - the custom specified textField font at 70% of its size
- * - `[UIFont boldSystemFontOfSize:12.0f]`
  */
 @property (nonatomic, strong) UIFont * floatingLabelFont;
 

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -61,7 +61,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [self addSubview:_floatingLabel];
 	
     // some basic default fonts/colors
-    _floatingLabelFont = [UIFont boldSystemFontOfSize:12.0f];
+    _floatingLabelFont = [self defaultFloatingLabelFont];
     _floatingLabel.font = _floatingLabelFont;
     _floatingLabelTextColor = [UIColor grayColor];
     _floatingLabel.textColor = _floatingLabelTextColor;
@@ -76,7 +76,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
 #pragma mark -
 
-- (void)updateDefaultFloatingLabelFont
+- (UIFont *)defaultFloatingLabelFont
 {
     UIFont *textFieldFont = nil;
     
@@ -90,7 +90,12 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         textFieldFont = self.font;
     }
     
-    UIFont *derivedFont = [UIFont fontWithName:textFieldFont.fontName size:roundf(textFieldFont.pointSize * 0.7f)];
+    return [UIFont fontWithName:textFieldFont.fontName size:roundf(textFieldFont.pointSize * 0.7f)];
+}
+
+- (void)updateDefaultFloatingLabelFont
+{
+    UIFont *derivedFont = [self defaultFloatingLabelFont];
     
     if (_isFloatingLabelFontDefault) {
         self.floatingLabelFont = derivedFont;
@@ -117,7 +122,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     if (floatingLabelFont != nil) {
         _floatingLabelFont = floatingLabelFont;
     }
-    _floatingLabel.font = _floatingLabelFont ? _floatingLabelFont : [UIFont boldSystemFontOfSize:12.0f];
+    _floatingLabel.font = _floatingLabelFont ? _floatingLabelFont : [self defaultFloatingLabelFont];
     _isFloatingLabelFontDefault = floatingLabelFont == nil;
     [self setFloatingLabelText:self.placeholder];
     [self invalidateIntrinsicContentSize];

--- a/JVFloatLabeledTextFieldTests/JVFloatLabeledTextFieldTests.m
+++ b/JVFloatLabeledTextFieldTests/JVFloatLabeledTextFieldTests.m
@@ -51,7 +51,7 @@
 {
     XCTAssertEqual(self.testField.floatingLabelYPadding, 0.0f);
     XCTAssertEqual(self.testField.placeholderYPadding, 0.0f);
-    XCTAssertEqual(self.testField.floatingLabelFont, [UIFont boldSystemFontOfSize:12.0f]);
+    XCTAssertNotNil(self.testField.floatingLabelFont);
     XCTAssertEqual(self.testField.floatingLabelFont, self.testField.floatingLabel.font);
     XCTAssert(CGColorEqualToColor(self.testField.floatingLabelTextColor.CGColor,
                                   [UIColor grayColor].CGColor));

--- a/JVFloatLabeledTextFieldTests/JVFloatLabeledTextViewTests.m
+++ b/JVFloatLabeledTextFieldTests/JVFloatLabeledTextViewTests.m
@@ -52,7 +52,7 @@
     XCTAssertEqual(self.testView.placeholderLabel.text, self.testView.placeholder);
     XCTAssertEqual(self.testView.floatingLabelYPadding, 0.0f);
     XCTAssertEqual(self.testView.placeholderYPadding, 0.0f);
-    XCTAssertEqual(self.testView.floatingLabelFont, [UIFont boldSystemFontOfSize:12.0f]);
+    XCTAssertNotNil(self.testView.floatingLabelFont);
     XCTAssertEqual(self.testView.floatingLabelFont, self.testView.floatingLabel.font);
     XCTAssert(CGColorEqualToColor(self.testView.floatingLabelTextColor.CGColor,
                                   [UIColor grayColor].CGColor));


### PR DESCRIPTION
# It is sufficient to use UITextField's default font instead of static fallback font.

Due to intialized font([UIFont boldSystemFontOfSize:12.0f]) & derived font at updateDefaultFloatingLabelFont difference make placeholder text shrink.
(In my case, setAttributedText: method call updateDefaultFloatingLabelFont when firstResponder changes)

According to [Apple Doc](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instp/UITextField/font), UITextField always have default font.

> The default font is a 12-point Helvetica plain font.

So, it doesn’t have to have fallback font : [UIFont boldSystemFontOfSize:12.0f].

Reference : Issue #98 