### PR TITLE
Floating label font bugfix

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -297,10 +297,6 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     
     [self setLabelOriginForTextAlignment];
     
-    if (self.floatingLabelFont) {
-        _floatingLabel.font = self.floatingLabelFont;
-    }
-    
     CGSize floatingLabelSize = [_floatingLabel sizeThatFits:_floatingLabel.superview.bounds.size];
     
     _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -168,10 +168,6 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     
     [self setLabelOriginForTextAlignment];
     
-    if (self.floatingLabelFont) {
-        _floatingLabel.font = self.floatingLabelFont;
-    }
-    
     BOOL firstResponder = self.isFirstResponder;
     _floatingLabel.textColor = (firstResponder && self.text && self.text.length > 0 ?
                                 self.labelActiveColor : self.floatingLabelTextColor);


### PR DESCRIPTION
Removed floating label font set because it overwrites the font the user
set with the default font. This assignment isn’t necessary at all.