### PR TITLE
Add a flag to always show floating label (even when text length is 0)

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -117,6 +117,12 @@ IB_DESIGNABLE
 @property (nonatomic, assign) IBInspectable BOOL keepBaseline;
 
 /**
+ * Force floating label to be always visible
+ * Defaults to NO
+ */
+@property (nonatomic, assign) BOOL alwaysShowFloatingLabel;
+
+/**
  *  Sets the placeholder and the floating title
  *
  *  @param placeholder The string that to be shown in the text field when no other text is present.

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -294,7 +294,8 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     return rect;
 }
 
-- (CGRect)rightViewRectForBounds:(CGRect)bounds {
+- (CGRect)rightViewRectForBounds:(CGRect)bounds
+{
     
     CGRect rect = [super rightViewRectForBounds:bounds];
     
@@ -315,10 +316,13 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [super setTextAlignment:textAlignment];
     [self setNeedsLayout];
 }
-- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel {
+
+- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel
+{
     _alwaysShowFloatingLabel = alwaysShowFloatingLabel;
     [self setNeedsLayout];
 }
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -315,7 +315,10 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [super setTextAlignment:textAlignment];
     [self setNeedsLayout];
 }
-
+- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel {
+    _alwaysShowFloatingLabel = alwaysShowFloatingLabel;
+    [self setNeedsLayout];
+}
 - (void)layoutSubviews
 {
     [super layoutSubviews];
@@ -332,7 +335,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     BOOL firstResponder = self.isFirstResponder;
     _floatingLabel.textColor = (firstResponder && self.text && self.text.length > 0 ?
                                 self.labelActiveColor : self.floatingLabelTextColor);
-    if (!self.text || 0 == [self.text length]) {
+    if ((!self.text || 0 == [self.text length]) && !self.alwaysShowFloatingLabel) {
         [self hideFloatingLabel:firstResponder];
     }
     else {

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.h
@@ -125,6 +125,12 @@ IB_DESIGNABLE
 @property (nonatomic, assign) NSTimeInterval floatingLabelHideAnimationDuration UI_APPEARANCE_SELECTOR;
 
 /**
+ * Force floating label to be always visible
+ * Defaults to NO
+ */
+@property (nonatomic, assign) BOOL alwaysShowFloatingLabel;
+
+/**
  *  Sets the placeholder and the floating title
  *
  *  @param placeholder The string that to be shown in the text view when no other text is present.

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -189,7 +189,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     BOOL firstResponder = self.isFirstResponder;
     _floatingLabel.textColor = (firstResponder && self.text && self.text.length > 0 ?
                                 self.labelActiveColor : self.floatingLabelTextColor);
-    if (!self.text || 0 == [self.text length]) {
+    if ((!self.text || 0 == [self.text length])&& !self.alwaysShowFloatingLabel) {
         [self hideFloatingLabel:firstResponder];
     }
     else {
@@ -207,7 +207,10 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     }
     return [UIColor blueColor];
 }
-
+- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel {
+    _alwaysShowFloatingLabel = alwaysShowFloatingLabel;
+    [self setNeedsLayout];
+}
 - (void)showFloatingLabel:(BOOL)animated
 {
     void (^showBlock)() = ^{

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -189,7 +189,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     BOOL firstResponder = self.isFirstResponder;
     _floatingLabel.textColor = (firstResponder && self.text && self.text.length > 0 ?
                                 self.labelActiveColor : self.floatingLabelTextColor);
-    if ((!self.text || 0 == [self.text length])&& !self.alwaysShowFloatingLabel) {
+    if ((!self.text || 0 == [self.text length]) && !self.alwaysShowFloatingLabel) {
         [self hideFloatingLabel:firstResponder];
     }
     else {
@@ -207,10 +207,13 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     }
     return [UIColor blueColor];
 }
-- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel {
+
+- (void)setAlwaysShowFloatingLabel:(BOOL)alwaysShowFloatingLabel
+{
     _alwaysShowFloatingLabel = alwaysShowFloatingLabel;
     [self setNeedsLayout];
 }
+
 - (void)showFloatingLabel:(BOOL)animated
 {
     void (^showBlock)() = ^{


### PR DESCRIPTION
Sometimes I've found it useful to force the floating label to be always visible even if there is no input inside the textfield. I've added a boolean property to allow this.