### PR TITLE
Floating label was being truncated when its title was being modified

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -134,7 +134,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         _floatingLabel.alpha = 1.0f;
         _floatingLabel.frame = CGRectMake(_floatingLabel.frame.origin.x,
                                           _floatingLabelYPadding,
-                                          _floatingLabel.frame.size.width,
+                                          self.frame.size.width,
                                           _floatingLabel.frame.size.height);
     };
     


### PR DESCRIPTION
The floating label was being truncated when its text was modified.

Corrected it by changing its frame's width to match textfield's width