### PR TITLE
Attributed Color Convenience Methods

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.h
@@ -123,11 +123,24 @@ IB_DESIGNABLE
 @property (nonatomic, assign) BOOL alwaysShowFloatingLabel;
 
 /**
+ * Color of the placeholder
+ */
+@property (nonatomic, strong) IBInspectable UIColor * placeholderColor;
+
+/**
  *  Sets the placeholder and the floating title
  *
  *  @param placeholder The string that to be shown in the text field when no other text is present.
  *  @param floatingTitle The string to be shown above the text field once it has been populated with text by the user.
  */
 - (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle;
+
+/**
+ *  Sets the attributed placeholder and the floating title
+ *
+ *  @param attributedPlaceholder The string that to be shown in the text field when no other text is present.
+ *  @param floatingTitle The string to be shown above the text field once it has been populated with text by the user.
+ */
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder floatingTitle:(NSString *)floatingTitle;
 
 @end

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -224,9 +224,20 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
                       textFieldIntrinsicContentSize.height + _floatingLabelYPadding + _floatingLabel.bounds.size.height);
 }
 
+- (void)setCorrectPlaceholder:(NSString *)placeholder
+{
+    if (self.placeholderColor) {
+        NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder
+                                                                                    attributes:@{NSForegroundColorAttributeName: self.placeholderColor}];
+        [super setAttributedPlaceholder:attributedPlaceholder];
+    } else{
+        [super setPlaceholder:placeholder];
+    }
+}
+
 - (void)setPlaceholder:(NSString *)placeholder
 {
-    [super setPlaceholder:placeholder];
+    [self setCorrectPlaceholder:placeholder];
     [self setFloatingLabelText:placeholder];
 }
 
@@ -239,7 +250,13 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
 - (void)setPlaceholder:(NSString *)placeholder floatingTitle:(NSString *)floatingTitle
 {
-    [super setPlaceholder:placeholder];
+    [self setCorrectPlaceholder:placeholder];
+    [self setFloatingLabelText:floatingTitle];
+}
+
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder floatingTitle:(NSString *)floatingTitle
+{
+    [super setAttributedPlaceholder:attributedPlaceholder];
     [self setFloatingLabelText:floatingTitle];
 }
 

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -226,11 +226,11 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
 - (void)setCorrectPlaceholder:(NSString *)placeholder
 {
-    if (self.placeholderColor) {
+    if (self.placeholderColor && placeholder) {
         NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder
                                                                                     attributes:@{NSForegroundColorAttributeName: self.placeholderColor}];
         [super setAttributedPlaceholder:attributedPlaceholder];
-    } else{
+    } else {
         [super setPlaceholder:placeholder];
     }
 }


### PR DESCRIPTION
## What this does

• Added a method to allow you to set attributed placeholder while also providing a separate float title.
• Added a method that allows you to set the desired placeholder color without having to set a color each time you set an attributed string.  (Note: if a placeholder color is set but you use attributed string you can still override the placeholder color)

## Reason for doing

• Method for setting both attributed placeholder and float title seems useful to have for scenarios where someone may need both
• In some setups (mine included) methods may exist that return a textfield that is setup with specific styles that should apply throughout the app.  Being able to set the placeholder color there allows us to keep code elsewhere cleaner.  Single point for color rather than each individual location we set a placeholder.