### PR TITLE
Tick 'Allow app extension API only' in framework target

### DIFF
--- a/JVFloatLabeledTextField.xcodeproj/project.pbxproj
+++ b/JVFloatLabeledTextField.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		639EABEF1B0B5E6F001DD7B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -459,6 +460,7 @@
 		639EABF01B0B5E6F001DD7B5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
With iOS 10 it is possible to write iMessage app which are almost like iOS app, but distributed as extensions.

This PR fixes nasty warning I have while developing such app:
```
ld: warning: linking against a dylib which is not safe for use in application extensions: ...Carthage/Build/iOS/JVFloatLabeledText.framework/JVFloatLabeledText
```
