### PR TITLE
Update placeholder when placeholderColor is set

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -260,6 +260,11 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     [self setFloatingLabelText:floatingTitle];
 }
 
+- (void)setPlaceholderColor:(UIColor *)color {
+    _placeholderColor = color;
+    [self setCorrectPlaceholder:self.placeholder];
+}
+
 - (CGRect)textRectForBounds:(CGRect)bounds
 {
     CGRect rect = [super textRectForBounds:bounds];


### PR DESCRIPTION
Fixes an issue where setting placeholderColor in Interface Builder would not have any effect since the placeholderColor was set after the placeholderText.