### PR TITLE
Added another init to JVFloatLabeledTextView

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -47,6 +47,15 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer
+{
+    self = [super initWithFrame:frame textContainer:textContainer];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];


### PR DESCRIPTION
Without that, `JVFloatLabeledTextView` **subclass** not properly initialized in a Swift project. The app crashes on runtime if any text view property is accessed.