### PR TITLE
Fix iOS 13 floating label default font

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -91,7 +91,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         textFieldFont = self.font;
     }
     
-    return [UIFont fontWithName:textFieldFont.fontName size:roundf(textFieldFont.pointSize * (_floatingLabelReductionRatio/100))];
+    return [textFieldFont fontWithSize:roundf(textFieldFont.pointSize * (_floatingLabelReductionRatio/100))];
 }
 
 - (void)updateDefaultFloatingLabelFont

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextView.m
@@ -144,7 +144,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
         textViewFont = self.placeholderLabel.font;
     }
     
-    return [UIFont fontWithName:textViewFont.fontName size:roundf(textViewFont.pointSize * 0.7f)];
+    return [textViewFont fontWithSize:roundf(textViewFont.pointSize * 0.7f)];
 }
 
 - (void)setPlaceholder:(NSString *)placeholder


### PR DESCRIPTION
In iOS 13 (GM) the text field default font name is `.SFUI-Regular` which for some reason, when used in `+fontWithName:size:` returns a Times New Roman UIFont.

This can be noted in the playground:
![playground font name bug](https://gonzobucket.s3-sa-east-1.amazonaws.com/Images/e884fb99-3afb-4003-b7e6-6cdd98b0c8b3.png)

and in an iOS app results in the floating label using Times New Roman as default font:
![ios app font bug](https://gonzobucket.s3-sa-east-1.amazonaws.com/Images/f7c759ba-de5d-48e3-ab13-299b0657f4c6.png)

Thus, `+fontWithName:size:` is not safe to create a copy of the font. In this PR I changed those calls to use `-fontWithSize:(CGFloat)fontSize` which fixes the problem:

![ios app font fix](https://gonzobucket.s3-sa-east-1.amazonaws.com/Images/22f950f6-c362-4126-a8e0-1da6b78e489e.png)