### PR TITLE
Fixed label title is not read when text was entered with using VoiceOver

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -148,6 +148,8 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     else {
         showBlock();
     }
+
+    self.accessibilityLabel = self.floatingLabel.text;
 }
 
 - (void)hideFloatingLabel:(BOOL)animated
@@ -171,6 +173,8 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     else {
         hideBlock();
     }
+
+    self.accessibilityLabel = nil;
 }
 
 - (void)setLabelOriginForTextAlignment


### PR DESCRIPTION
Fixed label title is not read when text was entered with using VoiceOver. https://github.com/jverdi/JVFloatLabeledTextField/issues/141

before:
https://drive.google.com/file/d/1ETBfw0ctMynvpbWmoBnDMB8X_Xytngel/view?usp=sharing

after:
https://drive.google.com/file/d/1B5ieARXdhYysIQP9KaBRb60-sJVLGTyx/view?usp=sharing
