### PR TITLE
Provide separate public headers for SwiftPM

### DIFF
--- a/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextField-Interface.h
+++ b/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextField-Interface.h
@@ -1,0 +1,1 @@
+../JVFloatLabeledTextField/JVFloatLabeledTextField.h

--- a/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextField.h
+++ b/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextField.h
@@ -1,0 +1,29 @@
+//
+//  JVFloatLabeledTextField.h
+//  JVFloatLabeledTextField
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2013-2015 Jared Verdi
+//  Original Concept by Matt D. Smith
+//  http://dribbble.com/shots/1254439--GIF-Mobile-Form-Interaction?list=users
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "JVFloatLabeledTextField-Interface.h"
+#import "JVFloatLabeledTextView.h"

--- a/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextView.h
+++ b/JVFloatLabeledTextField/SPMHeaders/JVFloatLabeledTextView.h
@@ -1,0 +1,1 @@
+../JVFloatLabeledTextField/JVFloatLabeledTextView.h

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             dependencies: [],
             path: "JVFloatLabeledTextField",
             sources: ["JVFloatLabeledTextField"],
-            publicHeadersPath: "JVFloatLabeledTextField"
+            publicHeadersPath: "SPMHeaders"
         )
     ]
 )


### PR DESCRIPTION
Fix for #220 

Add a dedicated folder to provide public headers for Swift Package Manager.
Folder contains 3 headers: 
1. Symlink to original `JVFloatLabeledTextField.h` renamed to `JVFloatLabeledTextField-Interface.h` to avoid name conflict
2. Symlink to original `JVFloatLabeledTextView.h`
3. A new header with the target name that lists all public headers `JVFloatLabeledTextField.h`

This was the best solution I could find that will:
- Fix SwiftPM integration in Xcode 12.5
- Won't make any changes to files not related to SPM integration. Should keep other integrations working
- Keep the target name `JVFloatLabeledTextField` to avoid changes in projects using this library
  - Carthage uses `JVFloatLabeledText` which may simplify some things for SwiftPM as well. This will avoid header naming conflicts, but will break existing imports