### PR TITLE
Accessibility label on text field is no longer nil when there is no text

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/JVFloatLabeledTextField.m
@@ -148,8 +148,6 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     else {
         showBlock();
     }
-
-    self.accessibilityLabel = self.floatingLabel.text;
 }
 
 - (void)hideFloatingLabel:(BOOL)animated
@@ -173,8 +171,6 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
     else {
         hideBlock();
     }
-
-    self.accessibilityLabel = nil;
 }
 
 - (void)setLabelOriginForTextAlignment
@@ -202,6 +198,7 @@ static CGFloat const kFloatingLabelHideAnimationDuration = 0.3f;
 
 - (void)setFloatingLabelText:(NSString *)text
 {
+    self.accessibilityLabel = text;
     _floatingLabel.text = text;
     [self setNeedsLayout];
 }


### PR DESCRIPTION
The text fields accessibility label only got set when text was entered, and changed to nil when there was no text. This change adds it in the setFloatingText method on init. 